### PR TITLE
Fix answer saving bug and add MathJax support

### DIFF
--- a/routes_answers.py
+++ b/routes_answers.py
@@ -8,7 +8,7 @@ from datetime import datetime
 from typing import Optional
 
 from database import get_db
-from models_v2 import Answer, Question, ClassMeeting, APIKey as APIKeyV2
+from models_v2 import Answer, Question, ClassMeeting, APIKey as APIKeyV2, Instructor
 from schemas_v2 import AnswerCreate, AnswerUpdate, AnswerResponse
 from logging_config import get_logger, log_database_operation
 

--- a/static/js/instructor.js
+++ b/static/js/instructor.js
@@ -398,8 +398,16 @@ function renderQuestions() {
             `;
         }).join('');
     }
-    
+
     questionsList.innerHTML = questionsHtml;
+
+    // Trigger MathJax to process the new content
+    if (window.MathJax && window.MathJax.typesetPromise) {
+        MathJax.typesetPromise().catch((err) => console.log('MathJax error:', err));
+    } else if (window.MathJax && window.MathJax.Hub) {
+        // MathJax 2.x fallback
+        MathJax.Hub.Queue(["Typeset", MathJax.Hub]);
+    }
 }
 
 async function toggleAnswered(questionId) {

--- a/templates/instructor.html
+++ b/templates/instructor.html
@@ -7,6 +7,28 @@
     <link rel="stylesheet" href="/static/css/styles.css">
     <!-- EasyMDE markdown editor CSS -->
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/easymde@2.18.0/dist/easymde.min.css">
+
+    <!-- MathJax for LaTeX rendering in questions -->
+    <script>
+        window.MathJax = {
+            tex: {
+                inlineMath: [['$', '$'], ['\\(', '\\)']],
+                displayMath: [['$$', '$$'], ['\\[', '\\]']],
+                processEscapes: true,
+                processEnvironments: true
+            },
+            options: {
+                skipHtmlTags: ['script', 'noscript', 'style', 'textarea', 'pre']
+            },
+            startup: {
+                ready: () => {
+                    console.log('MathJax is loaded and ready');
+                    MathJax.startup.defaultReady();
+                }
+            }
+        };
+    </script>
+    <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
     <style>
         header {
             background: var(--primary-color);

--- a/templates/stats.html
+++ b/templates/stats.html
@@ -4,6 +4,29 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Class Statistics</title>
+
+    <!-- MathJax for LaTeX rendering -->
+    <script>
+        window.MathJax = {
+            tex: {
+                inlineMath: [['$', '$'], ['\\(', '\\)']],
+                displayMath: [['$$', '$$'], ['\\[', '\\]']],
+                processEscapes: true,
+                processEnvironments: true
+            },
+            options: {
+                skipHtmlTags: ['script', 'noscript', 'style', 'textarea', 'pre']
+            },
+            startup: {
+                ready: () => {
+                    console.log('MathJax is loaded and ready');
+                    MathJax.startup.defaultReady();
+                }
+            }
+        };
+    </script>
+    <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
+
     <style>
         * {
             margin: 0;
@@ -762,6 +785,9 @@
                     </div>
                 `;
             }).join('');
+
+            // Trigger MathJax to process the new content
+            typesetMath();
         }
 
         function renderPaginatedQuestions(page) {
@@ -769,7 +795,7 @@
             const start = page * questionsPerPage;
             const end = start + questionsPerPage;
             const pageQuestions = allQuestions.slice(start, end);
-            
+
             const questionsList = document.getElementById('questions-list');
             questionsList.innerHTML = pageQuestions.map((q, idx) => {
                 const questionNum = q.question_number || (start + idx + 1);
@@ -783,6 +809,19 @@
                     </div>
                 `;
             }).join('');
+
+            // Trigger MathJax to process the new content
+            typesetMath();
+        }
+
+        // Helper function to safely trigger MathJax
+        function typesetMath() {
+            if (window.MathJax && window.MathJax.typesetPromise) {
+                MathJax.typesetPromise().catch((err) => console.log('MathJax error:', err));
+            } else if (window.MathJax && window.MathJax.Hub) {
+                // MathJax 2.x fallback
+                MathJax.Hub.Queue(["Typeset", MathJax.Hub]);
+            }
         }
 
         function showPagination(totalQuestions) {


### PR DESCRIPTION
- Fix NameError in routes_answers.py by importing Instructor model
- Add MathJax library to stats.html and instructor.html for LaTeX rendering
- Configure MathJax with synchronous loading to prevent initialization errors
- Update instructor.js to safely trigger MathJax typesetting
- Add proper existence checks before calling MathJax.typesetPromise()

This enables proper rendering of mathematical expressions (e.g., $\vec{a}$, $$E=mc^2$$) across all views: student, instructor, and stats pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)